### PR TITLE
Bases being captured by an enemy do not produce income

### DIFF
--- a/src/cljs/zetawar/game.cljs
+++ b/src/cljs/zetawar/game.cljs
@@ -102,6 +102,19 @@
       ffirst
       (or 0)))
 
+(defn faction-base-being-captured-count [db faction]
+  (-> (d/q '[:find (count ?b)
+             :in $ ?f
+             :where
+             [?b :terrain/owner ?f]
+             [(not= ?ef f)]
+             [?ef :faction/units ?u]
+             [?u :unit/terrain ?b]
+             [?u :unit/capturing true]]
+           db (e faction))
+      ffirst
+      (or 0)))
+
 (defn enemy-base-count [db faction]
   (-> (d/q '[:find (count ?b)
              :in $ ?f
@@ -133,8 +146,9 @@
 
 (defn income [db game faction]
   (let [base-count (faction-base-count db faction)
+        captured-count (faction-base-being-captured-count db faction)
         {:keys [game/credits-per-base]} game]
-    (* base-count credits-per-base)))
+    (* (- base-count captured-count) credits-per-base)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Terrain

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -158,6 +158,19 @@
                 conn)
        (into {})))
 
+(deftrack faction-eid->base-being-captured-count [conn]
+  (->> @(posh/q '[:find ?f (count ?t)
+                  :where
+                  [_ :app/game ?g]
+                  [?g :game/factions ?f]
+                  [?t :terrain/owner ?f]
+                  [(not= ?ef f)]
+                  [?ef :faction/units ?u]
+                  [?u :unit/terrain ?t]
+                  [?u :unit/capturing true]]
+                conn)
+       (into {})))
+
 (deftrack faction-eid->unit-count [conn]
   (->> @(posh/q '[:find ?f (count ?u)
                   :where
@@ -194,13 +207,17 @@
 (deftrack current-base-count [conn]
   (get @(faction-eid->base-count conn) @(current-faction-eid conn)))
 
+(deftrack current-base-being-captured-count [conn]
+  (get @(faction-eid->base-being-captured-count conn) @(current-faction-eid conn)))
+
 (deftrack current-unit-count [conn]
   (get @(faction-eid->unit-count conn) @(current-faction-eid conn)))
 
 (deftrack current-income [conn]
   (let [{:keys [game/credits-per-base]} @(game conn)]
     (* credits-per-base
-       @(current-base-count conn))))
+       (- @(current-base-count conn)
+          @(current-base-being-captured-count conn)))))
 
 (deftrack enemy-unit-count [conn]
   (or (ffirst @(posh/q '[:find (count ?u)


### PR DESCRIPTION
Closes #58 
- Add new tracks and function to check for bases being captured
- Subtract bases being captured from total bases when calculating income