### PR TITLE
Display terrain effects for selected and targeted terrains

### DIFF
--- a/src/cljs/zetawar/data.cljs
+++ b/src/cljs/zetawar/data.cljs
@@ -62,8 +62,6 @@
          "here</a>.")
 
     ;; Status information
-    :hover-tile-location "Hovering over tile: "
-    :none "none"
     :terrain-label "Terrain"
     :movement-cost-label "Movement Cost"
     :attack-bonus-label "Attack Bonus"

--- a/src/cljs/zetawar/data.cljs
+++ b/src/cljs/zetawar/data.cljs
@@ -64,6 +64,7 @@
     ;; Status information
     :hover-tile-location "Hovering over tile: "
     :none "none"
+    :terrain-label "Terrain"
     :movement-cost-label "Movement Cost"
     :attack-bonus-label "Attack Bonus"
     :armor-bonus-label "Armor Bonus"

--- a/src/cljs/zetawar/data.cljs
+++ b/src/cljs/zetawar/data.cljs
@@ -62,12 +62,13 @@
          "here</a>.")
 
     ;; Status information
-    :terrain-label "Terrain"
+    :tile-coordinates-label "X,Y (Tile Coordinates)"
+    :terrain-effects-label "Movement Cost, Attack Bonus, Armor Bonus"
     :movement-cost-label "Movement Cost"
     :attack-bonus-label "Attack Bonus"
     :armor-bonus-label "Armor Bonus"
-    :selected-label "Selected"
-    :targeted-label "Targeted"
+    :selected-label "Selected: "
+    :targeted-label "Targeted: "
 
     ;; Ending turn
     :end-turn-alert "Are you sure you want to end your turn? You still have available moves."

--- a/src/cljs/zetawar/data.cljs
+++ b/src/cljs/zetawar/data.cljs
@@ -64,6 +64,11 @@
     ;; Status information
     :hover-tile-location "Hovering over tile: "
     :none "none"
+    :movement-cost-label "Movement Cost"
+    :attack-bonus-label "Attack Bonus"
+    :armor-bonus-label "Armor Bonus"
+    :selected-label "Selected"
+    :targeted-label "Targeted"
     }})
 
 ;; TODO: remove redundant id keys (?)

--- a/src/cljs/zetawar/events/ui.cljs
+++ b/src/cljs/zetawar/events/ui.cljs
@@ -361,18 +361,3 @@
 (defmethod router/handle-event ::start-new-game
   [{:as handler-ctx :keys [ev-chan conn]} [_ scenario-id]]
   (app/start-new-game! handler-ctx scenario-id))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Tile coordinates
-
-(defmethod router/handle-event ::hover-hex-enter
-  [{:as handler-ctx :keys [ev-chan db]} [_ q r]]
-  (let [app (app/root db)]
-    {:tx [[:db/add (e app) :app/hover-q q]
-          [:db/add (e app) :app/hover-r r]]}))
-
-(defmethod router/handle-event ::hover-hex-leave
-  [{:as handler-ctx :keys [ev-chan db]} [_ q r]]
-  (let [app (app/root db)]
-      {:tx [[:db/retract (e app) :app/hover-q q]
-            [:db/retract (e app) :app/hover-r r]]}))

--- a/src/cljs/zetawar/game.cljs
+++ b/src/cljs/zetawar/game.cljs
@@ -292,7 +292,7 @@
 (defn unit-ex [message unit]
   (ex-info message (select-keys unit [:unit/q :unit/r])))
 
-(defn unit-terrain-stats [db unit terrain]
+(defn terrain-effects [db unit terrain]
   (only (d/q '[:find ?mc ?at ?ar
                :in $ ?u ?t
                :where

--- a/src/cljs/zetawar/game.cljs
+++ b/src/cljs/zetawar/game.cljs
@@ -292,6 +292,19 @@
 (defn unit-ex [message unit]
   (ex-info message (select-keys unit [:unit/q :unit/r])))
 
+(defn unit-terrain-stats [db unit terrain]
+  (only (d/q '[:find ?mc ?at ?ar
+               :in $ ?u ?t
+               :where
+               [?u  :unit/type ?ut]
+               [?t  :terrain/type ?tt]
+               [?tt :terrain-type/effects ?e]
+               [?e  :terrain-effect/unit-type ?ut]
+               [?e  :terrain-effect/attack-bonus ?at]
+               [?e  :terrain-effect/armor-bonus ?ar]
+               [?e  :terrain-effect/movement-cost ?mc]]
+             db (e unit) (e terrain))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Unit States
 

--- a/src/cljs/zetawar/game.cljs
+++ b/src/cljs/zetawar/game.cljs
@@ -6,7 +6,7 @@
    [zetawar.data :as data]
    [zetawar.db :as db :refer [e find-by qe qes qess]]
    [zetawar.hex :as hex]
-   [zetawar.util :refer [breakpoint inspect oonly only]]))
+   [zetawar.util :refer [breakpoint inspect oonly]]))
 
 ;; TODO: improve exception data
 
@@ -291,19 +291,6 @@
 
 (defn unit-ex [message unit]
   (ex-info message (select-keys unit [:unit/q :unit/r])))
-
-(defn unit-terrain-stats [db unit terrain]
-  (only (d/q '[:find ?mc ?at ?ar
-               :in $ ?u ?t
-               :where
-               [?u  :unit/type ?ut]
-               [?t  :terrain/type ?tt]
-               [?tt :terrain-type/effects ?e]
-               [?e  :terrain-effect/unit-type ?ut]
-               [?e  :terrain-effect/attack-bonus ?at]
-               [?e  :terrain-effect/armor-bonus ?ar]
-               [?e  :terrain-effect/movement-cost ?mc]]
-             db (e unit) (e terrain))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Unit States

--- a/src/cljs/zetawar/game.cljs
+++ b/src/cljs/zetawar/game.cljs
@@ -292,7 +292,7 @@
 (defn unit-ex [message unit]
   (ex-info message (select-keys unit [:unit/q :unit/r])))
 
-(defn terrain-effects [db unit terrain]
+(defn unit-terrain-effects [db unit terrain]
   (only (d/q '[:find ?mc ?at ?ar
                :in $ ?u ?t
                :where

--- a/src/cljs/zetawar/game.cljs
+++ b/src/cljs/zetawar/game.cljs
@@ -6,7 +6,7 @@
    [zetawar.data :as data]
    [zetawar.db :as db :refer [e find-by qe qes qess]]
    [zetawar.hex :as hex]
-   [zetawar.util :refer [breakpoint inspect oonly]]))
+   [zetawar.util :refer [breakpoint inspect oonly only]]))
 
 ;; TODO: improve exception data
 

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -454,9 +454,9 @@
     @(unit-at conn q r)))
 
 (deftrack unit-terrain-effects [conn unit-q unit-r terrain-q terrain-r]
-  (let [unit @(unit-at conn unit-q unit-r)
-        terrain @(terrain-at conn terrain-q terrain-r)]
-    (game/unit-terrain-effects @conn unit terrain)))
+  (when-let [unit @(unit-at conn unit-q unit-r)]
+    (let [terrain @(terrain-at conn terrain-q terrain-r)]
+      (game/unit-terrain-effects @conn unit terrain))))
 
 (deftrack selected-terrain-effects [conn]
   (when-let [[q r] @(selected-hex conn)]

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -453,19 +453,19 @@
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at conn q r)))
 
-(deftrack terrain-stats [conn unit-q unit-r terrain-q terrain-r]
+(deftrack terrain-effects [conn unit-q unit-r terrain-q terrain-r]
   (let [unit @(unit-at conn unit-q unit-r)
         terrain @(terrain-at conn terrain-q terrain-r)]
-    (game/unit-terrain-stats @conn unit terrain)))
+    (game/terrain-effects @conn unit terrain)))
 
-(deftrack selected-stats [conn]
+(deftrack selected-terrain-effects [conn]
   (when-let [[q r] @(selected-hex conn)]
-    @(terrain-stats conn q r q r)))
+    @(terrain-effects conn q r q r)))
 
-(deftrack targeted-stats [conn]
+(deftrack targeted-terrain-effects [conn]
   (when-let [[terrain-q terrain-r] @(targeted-hex conn)]
     (let [[unit-q unit-r] @(selected-hex conn)]
-      @(terrain-stats conn unit-q unit-r terrain-q terrain-r))))
+      @(terrain-effects conn unit-q unit-r terrain-q terrain-r))))
 
 (deftrack unit-selected? [conn]
   (when-let [[q r] @(selected-hex conn)]

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -575,12 +575,3 @@
 
 (deftrack configuring-new-game? [conn]
   (:app/configuring-new-game @(app conn)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Tile coordinates
-
-(deftrack hover-hex [conn]
-  (-> @(app conn)
-      (select-values [:app/hover-q
-                      :app/hover-r])
-      not-empty))

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -361,6 +361,11 @@
 (deftrack in-range-of-friend-at? [conn unit-q unit-r friend-q friend-r]
   (contains? @(friend-locations-in-range-of conn unit-q unit-r) [friend-q friend-r]))
 
+(deftrack unit-terrain-effects [conn unit-q unit-r terrain-q terrain-r]
+  (when-let [unit @(unit-at conn unit-q unit-r)]
+    (let [terrain @(terrain-at conn terrain-q terrain-r)]
+      (game/unit-terrain-effects @conn unit terrain))))
+
 (deftrack repairable? [conn q r]
   (when-let [unit @(unit-at conn q r)]
     (game/repairable? @conn @(game conn) unit)))
@@ -452,11 +457,6 @@
 (deftrack selected-unit [conn]
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at conn q r)))
-
-(deftrack unit-terrain-effects [conn unit-q unit-r terrain-q terrain-r]
-  (when-let [unit @(unit-at conn unit-q unit-r)]
-    (let [terrain @(terrain-at conn terrain-q terrain-r)]
-      (game/unit-terrain-effects @conn unit terrain))))
 
 (deftrack selected-terrain-effects [conn]
   (when-let [[q r] @(selected-hex conn)]

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -453,6 +453,20 @@
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at conn q r)))
 
+(deftrack terrain-stats [conn unit-q unit-r terrain-q terrain-r]
+  (let [unit @(unit-at conn unit-q unit-r)
+        terrain @(terrain-at conn terrain-q terrain-r)]
+    (game/unit-terrain-stats @conn unit terrain)))
+
+(deftrack selected-stats [conn]
+  (when-let [[q r] @(selected-hex conn)]
+    @(terrain-stats conn q r q r)))
+
+(deftrack targeted-stats [conn]
+  (when-let [[terrain-q terrain-r] @(targeted-hex conn)]
+    (let [[unit-q unit-r] @(selected-hex conn)]
+      @(terrain-stats conn unit-q unit-r terrain-q terrain-r))))
+
 (deftrack unit-selected? [conn]
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at? conn q r)))

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -453,20 +453,6 @@
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at conn q r)))
 
-(deftrack terrain-stats [conn unit-q unit-r terrain-q terrain-r]
-  (let [unit @(unit-at conn unit-q unit-r)
-        terrain @(terrain-at conn terrain-q terrain-r)]
-    (game/unit-terrain-stats @conn unit terrain)))
-
-(deftrack selected-stats [conn]
-  (when-let [[q r] @(selected-hex conn)]
-    @(terrain-stats conn q r q r)))
-
-(deftrack targeted-stats [conn]
-  (when-let [[terrain-q terrain-r] @(targeted-hex conn)]
-    (let [[unit-q unit-r] @(selected-hex conn)]
-      @(terrain-stats conn unit-q unit-r terrain-q terrain-r))))
-
 (deftrack unit-selected? [conn]
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at? conn q r)))

--- a/src/cljs/zetawar/subs.cljs
+++ b/src/cljs/zetawar/subs.cljs
@@ -453,19 +453,19 @@
   (when-let [[q r] @(selected-hex conn)]
     @(unit-at conn q r)))
 
-(deftrack terrain-effects [conn unit-q unit-r terrain-q terrain-r]
+(deftrack unit-terrain-effects [conn unit-q unit-r terrain-q terrain-r]
   (let [unit @(unit-at conn unit-q unit-r)
         terrain @(terrain-at conn terrain-q terrain-r)]
-    (game/terrain-effects @conn unit terrain)))
+    (game/unit-terrain-effects @conn unit terrain)))
 
 (deftrack selected-terrain-effects [conn]
   (when-let [[q r] @(selected-hex conn)]
-    @(terrain-effects conn q r q r)))
+    @(unit-terrain-effects conn q r q r)))
 
 (deftrack targeted-terrain-effects [conn]
   (when-let [[terrain-q terrain-r] @(targeted-hex conn)]
     (let [[unit-q unit-r] @(selected-hex conn)]
-      @(terrain-effects conn unit-q unit-r terrain-q terrain-r))))
+      @(unit-terrain-effects conn unit-q unit-r terrain-q terrain-r))))
 
 (deftrack unit-selected? [conn]
   (when-let [[q r] @(selected-hex conn)]

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -113,9 +113,7 @@
 (defn tile [{:as view-ctx :keys [dispatch]} terrain]
   (let [{:keys [terrain/q terrain/r]} terrain]
     ^{:key (str q "," r)}
-    [:g {:on-click #(dispatch [::events.ui/select-hex q r])
-         :on-mouse-enter #(dispatch [::events.ui/hover-hex-enter q r])
-         :on-mouse-leave #(dispatch [::events.ui/hover-hex-leave q r])}
+    [:g {:on-click #(dispatch [::events.ui/select-hex q r])}
      [terrain-tile view-ctx terrain q r]
      [tile-border view-ctx q r]
      [board-unit view-ctx q r]
@@ -272,33 +270,27 @@
                 :title (translate :configure-faction-tip)}]]]))))
 
 (defn status-info [{:as view-ctx :keys [conn translate]}]
-  (let [[hover-q hover-r] @(subs/hover-hex conn)]
-    [:div
-     [:p.hidden-xs.hidden-sm
-      (translate :hover-tile-location)
-      (if hover-q
-        (str hover-q ", " hover-r)
-        (translate :none))]
-     (when-let [[selected-mc selected-at selected-ar] @(subs/selected-stats conn)]
-       [:div.row.col-md-6
-        [:> js/ReactBootstrap.Table
-         [:thead>tr
-          [:th.text-center (translate :terrain-label)]
-          [:th.text-center (translate :movement-cost-label)]
-          [:th.text-center (translate :attack-bonus-label)]
-          [:th.text-center (translate :armor-bonus-label)]]
-         [:tbody
+  [:div
+   (when-let [[selected-mc selected-at selected-ar] @(subs/selected-stats conn)]
+     [:div.row.col-md-6
+      [:> js/ReactBootstrap.Table
+       [:thead>tr
+        [:th.text-center (translate :terrain-label)]
+        [:th.text-center (translate :movement-cost-label)]
+        [:th.text-center (translate :attack-bonus-label)]
+        [:th.text-center (translate :armor-bonus-label)]]
+       [:tbody
+        [:tr.text-center
+         [:td (translate :selected-label)]
+         [:td selected-mc]
+         [:td selected-at]
+         [:td selected-ar]]
+        (when-let [[targeted-mc targeted-at targeted-ar] @(subs/targeted-stats conn)]
           [:tr.text-center
-           [:td (translate :selected-label)]
-           [:td selected-mc]
-           [:td selected-at]
-           [:td selected-ar]]
-          (when-let [[targeted-mc targeted-at targeted-ar] @(subs/targeted-stats conn)]
-            [:tr.text-center
-             [:td (translate :targeted-label)]
-             [:td targeted-mc]
-             [:td targeted-at]
-             [:td targeted-ar]])]]])]))
+           [:td (translate :targeted-label)]
+           [:td targeted-mc]
+           [:td targeted-at]
+           [:td targeted-ar]])]]])])
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -318,8 +318,8 @@
           (str tar-mc "," tar-at "," tar-ar)]
          ")"]
         [:span " -"])
-      " • "
       [:span.hidden-xs.hidden-sm
+       " • "
        (translate :hover-tile-location)
        (if hover-q
          (str hover-q "," hover-r)

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -273,22 +273,11 @@
 
 (defn status-info [{:as view-ctx :keys [conn translate]}]
   (let [[hover-q hover-r] @(subs/hover-hex conn)]
-    [:div
-     [:p.hidden-xs.hidden-sm
-      (translate :hover-tile-location)
-      (if hover-q
-        (str hover-q ", " hover-r)
-        (translate :none))]
-     (when @(subs/selected-unit conn)
-       [:p "Selected: "
-        (interleave
-         ["Movement Cost: ", " Attack Bonus: ", " Armor Bonus: "]
-         @(subs/selected-stats conn))])
-     (when @(subs/targeted-hex conn)
-       [:p "Targeted: "
-        (interleave
-         ["Movement Cost: ", " Attack Bonus: ", " Armor Bonus: "]
-         @(subs/targeted-stats conn))])]))
+    [:p.hidden-xs.hidden-sm
+     (translate :hover-tile-location)
+     (if hover-q
+       (str hover-q ", " hover-r)
+       (translate :none))]))
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -271,7 +271,7 @@
 
 (defn status-info [{:as view-ctx :keys [conn translate]}]
   [:div
-   (when-let [[selected-mc selected-at selected-ar] @(subs/selected-stats conn)]
+   (when-let [[selected-mc selected-at selected-ar] @(subs/selected-terrain-effects conn)]
      [:div.row.col-md-6
       [:> js/ReactBootstrap.Table
        [:thead>tr
@@ -285,7 +285,7 @@
          [:td selected-mc]
          [:td selected-at]
          [:td selected-ar]]
-        (when-let [[targeted-mc targeted-at targeted-ar] @(subs/targeted-stats conn)]
+        (when-let [[targeted-mc targeted-at targeted-ar] @(subs/targeted-terrain-effects conn)]
           [:tr.text-center
            [:td (translate :targeted-label)]
            [:td targeted-mc]

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -273,11 +273,22 @@
 
 (defn status-info [{:as view-ctx :keys [conn translate]}]
   (let [[hover-q hover-r] @(subs/hover-hex conn)]
-    [:p.hidden-xs.hidden-sm
-     (translate :hover-tile-location)
-     (if hover-q
-       (str hover-q ", " hover-r)
-       (translate :none))]))
+    [:div
+     [:p.hidden-xs.hidden-sm
+      (translate :hover-tile-location)
+      (if hover-q
+        (str hover-q ", " hover-r)
+        (translate :none))]
+     (when @(subs/selected-unit conn)
+       [:p "Selected: "
+        (interleave
+         ["Movement Cost: ", " Attack Bonus: ", " Armor Bonus: "]
+         @(subs/selected-stats conn))])
+     (when @(subs/targeted-hex conn)
+       [:p "Targeted: "
+        (interleave
+         ["Movement Cost: ", " Attack Bonus: ", " Armor Bonus: "]
+         @(subs/targeted-stats conn))])]))
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -279,16 +279,26 @@
       (if hover-q
         (str hover-q ", " hover-r)
         (translate :none))]
-     (when @(subs/selected-unit conn)
-       [:p "Selected: "
-        (interleave
-         ["Movement Cost: ", " Attack Bonus: ", " Armor Bonus: "]
-         @(subs/selected-stats conn))])
-     (when @(subs/targeted-hex conn)
-       [:p "Targeted: "
-        (interleave
-         ["Movement Cost: ", " Attack Bonus: ", " Armor Bonus: "]
-         @(subs/targeted-stats conn))])]))
+     (when-let [[selected-mc selected-at selected-ar] @(subs/selected-stats conn)]
+       [:div.row.col-md-6
+        [:> js/ReactBootstrap.Table
+         [:thead>tr
+          [:th.text-center (translate :terrain-label)]
+          [:th.text-center (translate :movement-cost-label)]
+          [:th.text-center (translate :attack-bonus-label)]
+          [:th.text-center (translate :armor-bonus-label)]]
+         [:tbody
+          [:tr.text-center
+           [:td (translate :selected-label)]
+           [:td selected-mc]
+           [:td selected-at]
+           [:td selected-ar]]
+          (when-let [[targeted-mc targeted-at targeted-ar] @(subs/targeted-stats conn)]
+            [:tr.text-center
+             [:td (translate :targeted-label)]
+             [:td targeted-mc]
+             [:td targeted-at]
+             [:td targeted-ar]])]]])]))
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -271,26 +271,22 @@
 
 (defn status-info [{:as view-ctx :keys [conn translate]}]
   [:div
-   (when-let [[selected-mc selected-at selected-ar] @(subs/selected-terrain-effects conn)]
-     [:div.row.col-md-6
-      [:> js/ReactBootstrap.Table
-       [:thead>tr
-        [:th.text-center (translate :terrain-label)]
-        [:th.text-center (translate :movement-cost-label)]
-        [:th.text-center (translate :attack-bonus-label)]
-        [:th.text-center (translate :armor-bonus-label)]]
-       [:tbody
-        [:tr.text-center
-         [:td (translate :selected-label)]
-         [:td selected-mc]
-         [:td selected-at]
-         [:td selected-ar]]
-        (when-let [[targeted-mc targeted-at targeted-ar] @(subs/targeted-terrain-effects conn)]
-          [:tr.text-center
-           [:td (translate :targeted-label)]
-           [:td targeted-mc]
-           [:td targeted-at]
-           [:td targeted-ar]])]]])])
+   (let [[sel-q sel-r] @(subs/selected-hex conn)
+         [tar-q tar-r] @(subs/targeted-hex conn)]
+     [:span
+      "Selected: "
+      (if sel-q
+        (str
+         sel-q "," sel-r " "
+         "(" (string/join "," @(subs/selected-terrain-effects conn)) ")")
+        " -")
+      " • "
+      "Targeted: "
+      (if tar-q
+        (str
+         tar-q "," tar-r " "
+         "(" (string/join "," @(subs/targeted-terrain-effects conn)) ")")
+        " -")])])
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -288,21 +288,33 @@
 (defn status-info [{:as view-ctx :keys [conn translate]}]
   [:div
    (let [[sel-q sel-r] @(subs/selected-hex conn)
-         [tar-q tar-r] @(subs/targeted-hex conn)]
+         [tar-q tar-r] @(subs/targeted-hex conn)
+         [sel-mc sel-at sel-ar] @(subs/selected-terrain-effects conn)
+         [tar-mc tar-at tar-ar] @(subs/targeted-terrain-effects conn)]
      [:span
-      "Selected: "
+      (translate :selected-label)
       (if sel-q
-        (str
-         sel-q "," sel-r " "
-         "(" (string/join "," @(subs/selected-terrain-effects conn)) ")")
-        " -")
+        [:span
+         [:abbr {:title (translate :tile-coordinates-label) :style {:cursor "inherit"}}
+          (str sel-q "," sel-r)]
+         (if sel-mc ;; If selected doesn't contain a unit
+           [:span
+            " ("
+            [:abbr {:title (translate :terrain-effects-label) :style {:cursor "inherit"}}
+             (str sel-mc "," sel-at "," sel-ar)]
+            ")"])]
+        [:span " -"])
       " • "
-      "Targeted: "
+      (translate :targeted-label)
       (if tar-q
-        (str
-         tar-q "," tar-r " "
-         "(" (string/join "," @(subs/targeted-terrain-effects conn)) ")")
-        " -")])])
+        [:span
+         [:abbr {:title (translate :tile-coordinates-label) :style {:cursor "inherit"}}
+          (str tar-q "," tar-r)]
+         " ("
+         [:abbr {:title (translate :terrain-effects-label) :style {:cursor "inherit"}}
+          (str tar-mc "," tar-at "," tar-ar)]
+         ")"]
+        [:span " -"])])])
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -292,7 +292,8 @@
    (let [[sel-q sel-r] @(subs/selected-hex conn)
          [tar-q tar-r] @(subs/targeted-hex conn)
          [sel-mc sel-at sel-ar] @(subs/selected-terrain-effects conn)
-         [tar-mc tar-at tar-ar] @(subs/targeted-terrain-effects conn)]
+         [tar-mc tar-at tar-ar] @(subs/targeted-terrain-effects conn)
+         [hover-q hover-r] @(subs/hover-hex conn)]
      [:span
       (translate :selected-label)
       (if sel-q
@@ -316,13 +317,13 @@
          [:abbr {:title (translate :terrain-effects-label) :style {:cursor "inherit"}}
           (str tar-mc "," tar-at "," tar-ar)]
          ")"]
-        [:span " -"])])
-   (let [[hover-q hover-r] @(subs/hover-hex conn)]
-     [:span.hidden-xs.hidden-sm
-      (translate :hover-tile-location)
-      (if hover-q
-        (str hover-q "," hover-r)
-        "-")])])
+        [:span " -"])
+      " • "
+      [:span.hidden-xs.hidden-sm
+       (translate :hover-tile-location)
+       (if hover-q
+         (str hover-q "," hover-r)
+         "-")]])])
 
 (def armor-type-abbrevs
   {:unit-type.armor-type/personnel "P"


### PR DESCRIPTION
Closes #55
The terrain effects are displayed underneath the map in a small Bootstrap table.
<img width="474" alt="pic" src="https://user-images.githubusercontent.com/4776715/28106963-e179581c-66b3-11e7-9dba-9e35c1661504.png">

