### PR TITLE
Put all unit-picker text in dict

### DIFF
--- a/src/cljs/zetawar/data.cljs
+++ b/src/cljs/zetawar/data.cljs
@@ -29,6 +29,10 @@
     :green-name "Green"
     :orange-name "Orange"
 
+    ;; Armor types
+    :personnel-name "Personnel"
+    :armored-name "Armored"
+
     ;; New game settings
     :new-game-title "Start a new game"
     :scenario-label "Scenario"
@@ -44,7 +48,15 @@
 
     ;; Building units
     :build-title "Select a unit to build"
-    :unit-cost-label "Cost"
+    :unit-cost-label "Cost: "
+    :armor-type-label "Armor Type"
+    :movement-label "Move- ment"
+    :armor-label "Armor"
+    :range-label "Range"
+    :attack-label "Attack"
+    :field-repair-label "Field Repair?"
+    :while-capturing-label "While capturing: "
+    :unit-cannot-capture-bases-label "Unit cannot capture bases"
 
     ;; Win dialog
     :win-title "Congratulations! You won!"

--- a/src/cljs/zetawar/views.cljs
+++ b/src/cljs/zetawar/views.cljs
@@ -292,17 +292,17 @@
        [:thead>tr
         [:th ""]
         [:th.text-center {:style {:width "12%"}}
-         "Armor Type"]
+         (translate :armor-type-label)]
         [:th.text-center {:style {:width "12%"}}
-         "Move- ment"]
+         (translate :movement-label)]
         [:th.text-center {:style {:width "12%"}}
-         "Armor"]
+         (translate :armor-label)]
         [:th.text-center {:style {:width "12%"}}
-         "Range"]
+         (translate :range-label)]
         [:th.text-center {:style {:width "12%"}}
-         "Attack"]
+         (translate :attack-label)]
         [:th.text-center {:style {:width "12%"}}
-         "Field Repair?"]]
+         (translate :field-repair-label)]]
        (into [:tbody]
              (for [unit-type unit-types]
                (let [;; TODO: replace with unit-type-image
@@ -335,21 +335,24 @@
                     [:img {:src image}]]
                    [:div.media-body
                     [:h4.media-heading description]
-                    (str "Cost: " cost)]]
+                    (str (translate :unit-cost-label) cost)]]
                   [:td (case armor-type
                          :unit-type.armor-type/personnel
-                         [:abbr {:title "Personnel" :style {:cursor "inherit"}}
+                         [:abbr {:title (translate :personnel-name)
+                                 :style {:cursor "inherit"}}
                           armor-type-abbrev]
 
                          :unit-type.armor-type/armored
-                         [:abbr {:title "Armored" :style {:cursor "inherit"}}
+                         [:abbr {:title (translate :armored-name)
+                                 :style {:cursor "inherit"}}
                           armor-type-abbrev])]
                   [:td movement]
                   [:td (if can-capture
-                         [:abbr {:title (str "While capturing: " capturing-armor)
+                         [:abbr {:title (str (translate :while-capturing-label)
+                                             capturing-armor)
                                  :style {:cursor "inherit"}}
                           armor]
-                         [:abbr {:title "Unit cannot capture bases"
+                         [:abbr {:title (translate :unit-cannot-capture-bases-label)
                                  :style {:cursor "inherit"}}
                           armor])]
                   [:td min-range "-" max-range]
@@ -364,7 +367,7 @@
                                       (armor-type-abbrevs can-repair "")))]])))]]
      [:> js/ReactBootstrap.Modal.Footer
       [:div.btn.btn-default {:on-click hide-picker}
-       "Cancel"]]]))
+       (translate :cancel-button)]]]))
 
 (defn faction-settings [{:as views-ctx :keys [conn dispatch translate]}]
   (with-let [faction (subs/faction-to-configure conn)


### PR DESCRIPTION
When I expanded the amount of information shown in the unit-picker, I forgot to put the new UI text in the dict, so here's a fix for that. Since it isn't really a bug, and will only affect future features like localization, I'm pushing this to the master branch and not as a bug fix to 0.1.0.